### PR TITLE
Adds basic support for hex literals

### DIFF
--- a/__tests__/lexer.spec.ts
+++ b/__tests__/lexer.spec.ts
@@ -94,6 +94,18 @@ describe('should lex a function returning a literal', () => {
         new Token(Tokens.Number, '-1.0'),
       ]);
     });
+
+    it('0xDEADBEEF', () => {
+      const scanner = new Scanner(`
+        returnsDeadBeef => 0xDEADBEEF
+      `);
+      const lexer = new Lexer(scanner);
+      expect(Array.from(lexer)).toMatchObject([
+        new Token(Tokens.Identifier, 'returnsDeadBeef'),
+        new Token(Tokens.Arrow, '=>'),
+        new Token(Tokens.Number, '0xDEADBEEF'),
+      ]);
+    });
   });
 
   it('string', () => {

--- a/src/parser/lexer.ts
+++ b/src/parser/lexer.ts
@@ -9,6 +9,7 @@ export class Lexer implements Iterable<Token> {
   private static readonly matchIdentifier = /[_a-zA-Z][_a-zA-Z0-9]{0,30}/;
   private static readonly matchLiteralBool = /true|false/;
   private static readonly matchLiteralNumber = /-?\d+\.?\d*/;
+  private static readonly matchHexNumber = /0[xX][0-9a-fA-F]+/;
   private static readonly matchLiteralString = /(?=["'])(?:"[^"\\]*(?:\\[\s\S][^"\\]*)*"|'[^'\\]*(?:\\[\s\S][^'\\]*)*')/;
 
   constructor(private readonly scanner: Scanner) {}
@@ -112,6 +113,7 @@ export class Lexer implements Iterable<Token> {
   protected scanLiteral(): Token | undefined {
     return (
       this.scanOptional(Tokens.Boolean, Lexer.matchLiteralBool) ||
+      this.scanOptional(Tokens.Number, Lexer.matchHexNumber) ||
       this.scanOptional(Tokens.Number, Lexer.matchLiteralNumber) ||
       this.scanOptional(Tokens.String, Lexer.matchLiteralString)
     );


### PR DESCRIPTION
The matchHexNumber optional matcher has to come before the number matcher, otherwise the leading zero will get split off as a single digit number.