### PR TITLE
Add more AST source info, improved errors

### DIFF
--- a/src/cli/entrypoint.ts
+++ b/src/cli/entrypoint.ts
@@ -60,11 +60,22 @@ export function run(options: IOptions): void {
     process.stdin.on('data', chunk => {
       buffer += chunk;
       if (buffer.endsWith('\n\n')) {
-        const output = parse(buffer).visit(new visitor());
-        // tslint:disable-next-line:no-any
-        process.stdout.write(output as any);
-        process.stdout.write('\n');
-        buffer = '';
+        try {
+          const output = parse(buffer).visit(new visitor());
+          // tslint:disable-next-line:no-any
+          process.stdout.write(output as any);
+          process.stdout.write('\n');
+        } catch (e) {
+          if (e instanceof SyntaxError) {
+            process.stderr.write((e as Error).message);
+            process.stderr.write('\n');
+            process.stderr.write('\n');
+          } else {
+            throw e;
+          }
+        } finally {
+          buffer = '';
+        }
       }
     });
     process.on('SIGINT', () => {

--- a/src/parser/source/ast/node.ts
+++ b/src/parser/source/ast/node.ts
@@ -3,11 +3,40 @@ import { AstVisitor } from './visitor';
 
 export abstract class AstNode {
   public abstract visit(visitor: AstVisitor): void;
+
+  /**
+   * Offset from the beginning of the file to the first character.
+   */
+  public get offset(): number {
+    /* istanbul ignore next */
+    return this.beginToken.span.start.offset;
+  }
+
+  /**
+   * Number of characters in the syntactic entity's source range.
+   */
+  public get length(): number {
+    /* istanbul ignore next */
+    return this.beginToken.span.end.offset - this.endToken.span.start.offset;
+  }
+
+  public abstract get beginToken(): Token;
+  public abstract get endToken(): Token;
 }
 
 export class AstCompilationUnit extends AstNode {
   constructor(public readonly functions: AstFunctionDeclaration[]) {
     super();
+  }
+
+  public get beginToken(): Token {
+    /* istanbul ignore next */
+    return this.functions[0].beginToken;
+  }
+
+  public get endToken(): Token {
+    /* istanbul ignore next */
+    return this.functions[this.functions.length - 1].endToken;
   }
 
   public visit(visitor: AstVisitor): void {
@@ -23,11 +52,23 @@ export type AstExpression =
   | AstInvocationExpression
   | AstParenthesizedExpression;
 
-export class AstLiteralIdentifier extends AstNode {
-  constructor(private readonly token: Token) {
+export abstract class AstLiteralExpression extends AstNode {
+  constructor(protected readonly token: Token) {
     super();
   }
 
+  public get beginToken(): Token {
+    /* istanbul ignore next */
+    return this.token;
+  }
+
+  public get endToken(): Token {
+    /* istanbul ignore next */
+    return this.token;
+  }
+}
+
+export class AstLiteralIdentifier extends AstLiteralExpression {
   public get name(): string {
     return this.token.value;
   }
@@ -37,8 +78,40 @@ export class AstLiteralIdentifier extends AstNode {
   }
 }
 
+export class AstLiteralBoolean extends AstLiteralExpression {
+  public get value(): boolean {
+    return this.token.value === 'true';
+  }
+
+  public visit(visitor: AstVisitor): void {
+    return visitor.visitLiteralBoolean(this);
+  }
+}
+
+export class AstLiteralNumber extends AstLiteralExpression {
+  public get value(): number {
+    return parseFloat(this.token.value);
+  }
+
+  public visit(visitor: AstVisitor): void {
+    return visitor.visitLiteralNumber(this);
+  }
+}
+
+export class AstLiteralString extends AstLiteralExpression {
+  public get value(): string {
+    return this.token.value.substring(1, this.token.value.length - 1);
+  }
+
+  public visit(visitor: AstVisitor): void {
+    return visitor.visitLiteralString(this);
+  }
+}
+
 export class AstInvocationExpression extends AstNode {
   constructor(
+    public readonly beginToken: Token,
+    public readonly endToken: Token,
     public readonly target: AstExpression,
     public readonly args: AstExpression[]
   ) {
@@ -51,7 +124,11 @@ export class AstInvocationExpression extends AstNode {
 }
 
 export class AstParenthesizedExpression extends AstNode {
-  constructor(public readonly body: AstExpression[]) {
+  constructor(
+    public readonly beginToken: Token,
+    public readonly endToken: Token,
+    public readonly body: AstExpression[]
+  ) {
     super();
   }
 
@@ -60,51 +137,10 @@ export class AstParenthesizedExpression extends AstNode {
   }
 }
 
-export class AstLiteralBoolean extends AstNode {
-  constructor(private readonly token: Token) {
-    super();
-  }
-
-  public get value(): boolean {
-    return this.token.value === 'true';
-  }
-
-  public visit(visitor: AstVisitor): void {
-    return visitor.visitLiteralBoolean(this);
-  }
-}
-
-export class AstLiteralNumber extends AstNode {
-  constructor(private readonly token: Token) {
-    super();
-  }
-
-  public get value(): number {
-    return parseFloat(this.token.value);
-  }
-
-  public visit(visitor: AstVisitor): void {
-    return visitor.visitLiteralNumber(this);
-  }
-}
-
-export class AstLiteralString extends AstNode {
-  constructor(private readonly token: Token) {
-    super();
-  }
-
-  public get value(): string {
-    return this.token.value.substring(1, this.token.value.length - 1);
-  }
-
-  public visit(visitor: AstVisitor): void {
-    return visitor.visitLiteralString(this);
-  }
-}
-
 export class AstFunctionDeclaration extends AstNode {
   constructor(
-    private readonly token: Token,
+    public readonly beginToken: Token,
+    public readonly endToken: Token,
     public readonly parameters: AstLiteralIdentifier[],
     public readonly body: AstExpression[]
   ) {
@@ -112,7 +148,7 @@ export class AstFunctionDeclaration extends AstNode {
   }
 
   public get name(): string {
-    return this.token.value;
+    return this.beginToken.value;
   }
 
   public visit(visitor: AstVisitor): void {

--- a/src/parser/source/tokenizer/lexer.ts
+++ b/src/parser/source/tokenizer/lexer.ts
@@ -49,14 +49,14 @@ export class Lexer implements Iterable<Token> {
    * @param message
    */
   protected fail(message: string): never {
-    throw new SyntaxError(this.scanner.span.message(message));
+    throw new SyntaxError(this.scanner.span.highlight(message));
   }
 
   protected scanOptional(kind: TokenKind): Token | undefined {
     this.consumeWhitespace();
     const result = this.scanner.scan(kind.pattern);
     return result
-      ? new Token(kind, this.scanner.lastPosition, this.scanner.lastMatch![0])
+      ? new Token(kind, this.scanner.lastSpan(), this.scanner.lastMatch![0])
       : undefined;
   }
 
@@ -75,11 +75,7 @@ export class Lexer implements Iterable<Token> {
       }
       this.fail(`Expected ${pattern}, got "${this.substring}"`);
     }
-    return new Token(
-      kind,
-      this.scanner.lastPosition,
-      this.scanner.lastMatch![0]
-    );
+    return new Token(kind, this.scanner.lastSpan(), this.scanner.lastMatch![0]);
   }
 
   protected scanCompilationUnit(): Iterable<Token> {
@@ -168,6 +164,6 @@ export class Lexer implements Iterable<Token> {
     while (!this.scanOptional(SymbolToken.RParen)) {
       yield* this.scanExpression();
     }
-    yield new Token(SymbolToken.RParen, this.scanner.lastPosition, ')');
+    yield new Token(SymbolToken.RParen, this.scanner.lastSpan(), ')');
   }
 }

--- a/src/parser/source/tokenizer/lexer.ts
+++ b/src/parser/source/tokenizer/lexer.ts
@@ -95,7 +95,10 @@ export class Lexer implements Iterable<Token> {
     if (this.scanner.peek() === Characters.LParen) {
       yield* this.scanParantheses();
     } else if (!identifier) {
-      return this.fail(`Expected expression, got "${this.substring}"`);
+      const substring = this.substring;
+      this.scanner.read();
+      this.consumeWhitespace();
+      return this.fail(`Expected expression, got "${substring}"`);
     }
   }
 

--- a/src/parser/source/tokenizer/scanner.ts
+++ b/src/parser/source/tokenizer/scanner.ts
@@ -80,6 +80,13 @@ export class SourceScanner {
     return new SourceSpan(start, end, match);
   }
 
+  /**
+   * Returns the last match as a @see {SourceSpan}.
+   */
+  public lastSpan(): SourceSpan {
+    return this.mSourceFile.span(this.lastPosition, this.position);
+  }
+
   public get substring(): string {
     return this.contents.substring(this.position);
   }
@@ -370,7 +377,9 @@ export class SourceSpan {
     let buffer = '';
     if (startLine === endLine) {
       if (this.start instanceof FileLocation) {
-        buffer += `Line ${startLine + 1 + 1}${this.source ? ` in <${this.source}> `: ''}:\n`;
+        buffer += `Line ${startLine + 1 + 1}${
+          this.source ? ` in <${this.source}> ` : ''
+        }:\n`;
         const substring = this.start.file.readLine(startLine);
         buffer += `  ${substring}\n`;
         buffer += `  ${' '.repeat(this.start.column)}${'^'.repeat(
@@ -385,7 +394,7 @@ export class SourceSpan {
           buffer += `<${this.source}>:\n`;
         }
         for (let l = startLine; l < endLine + 1; l++) {
-          buffer += `${l + 1}: ${this.start.file.readLine(l)}\n`
+          buffer += `${l + 1}: ${this.start.file.readLine(l)}\n`;
         }
       } else {
         return this.message(message);

--- a/src/parser/source/tokenizer/scanner.ts
+++ b/src/parser/source/tokenizer/scanner.ts
@@ -376,28 +376,22 @@ export class SourceSpan {
     const endLine = this.end.line;
     let buffer = '';
     if (startLine === endLine) {
-      if (this.start instanceof FileLocation) {
-        buffer += `Line ${startLine + 1 + 1}${
-          this.source ? ` in <${this.source}> ` : ''
-        }:\n`;
-        const substring = this.start.file.readLine(startLine);
-        buffer += `  ${substring}\n`;
-        buffer += `  ${' '.repeat(this.start.column)}${'^'.repeat(
-          this.text.length
-        )}`;
-      } else {
-        return this.message(message);
-      }
+      const start = this.start as FileLocation;
+      buffer += `Line ${startLine + 1 + 1}${
+        this.source ? ` in <${this.source}>` : ''
+      }:\n`;
+      const substring = start.file.readLine(startLine);
+      buffer += `  ${substring}\n`;
+      buffer += `  ${' '.repeat(this.start.column)}${'^'.repeat(
+        this.text.length
+      )}`;
     } else {
-      if (this.start instanceof FileLocation) {
-        if (this.source) {
-          buffer += `<${this.source}>:\n`;
-        }
-        for (let l = startLine; l < endLine + 1; l++) {
-          buffer += `${l + 1}: ${this.start.file.readLine(l)}\n`;
-        }
-      } else {
-        return this.message(message);
+      if (this.source) {
+        buffer += `<${this.source}>:\n`;
+      }
+      for (let l = startLine; l < endLine + 1; l++) {
+        const start = this.start as FileLocation;
+        buffer += `${l + 1}: ${start.file.readLine(l)}\n`;
       }
     }
     buffer += `\n${message}`;

--- a/src/parser/source/tokenizer/tokens.ts
+++ b/src/parser/source/tokenizer/tokens.ts
@@ -1,11 +1,12 @@
 import { Characters } from './characters';
+import { SourceSpan } from './scanner';
 
 export class Token {
   public readonly value: string;
 
   constructor(
     public readonly kind: TokenKind,
-    public readonly offset: number,
+    public readonly span: SourceSpan,
     value: string
   ) {
     this.value = value;

--- a/tests/parser/source/tokenizer/scanner.spec.ts
+++ b/tests/parser/source/tokenizer/scanner.spec.ts
@@ -240,8 +240,6 @@ describe('SourceSpan', () => {
     const span = new SourceSpan(
       new SourceLocation(12, { source: 'names.json' }),
       new SourceLocation(15, { source: 'names.json' }),
-      // {"names": ["Abe", "George"]}
-      //             ^^^
       'Abe'
     );
     expect(span.message('Invalid name')).toBe(
@@ -249,13 +247,24 @@ describe('SourceSpan', () => {
     );
   });
 
+  it('should return a formatted message without a source URL', () => {
+    const span = new SourceSpan(
+      new SourceLocation(12),
+      new SourceLocation(15),
+      'Abe'
+    );
+    expect(span.message('Invalid name')).toBe(
+      'line 1, column 13: Invalid name'
+    );
+  });
+
   it('should return a highlighted message from 1 line', () => {
-    const file = new SourceFile('{"names": ["Abe", "George"]}');
+    const file = new SourceFile('{"names": ["Abe", "George"]}', 'names.json');
     const span = file.span(12, 15);
     // {"names": ["Abe", "George"]}
     //             ^^^
     expect(span.highlight('Invalid name')).toBe(
-      'Line 1:\n' +
+      'Line 1 in <names.json>:\n' +
         '  {"names": ["Abe", "George"]}\n' +
         '              ^^^\n' +
         'Invalid name'
@@ -263,10 +272,16 @@ describe('SourceSpan', () => {
   });
 
   it('should return a highlighted message from >1 line', () => {
-    const file = new SourceFile('[\n  1,\n  2,\n]');
+    const file = new SourceFile('[\n  1,\n  2,\n]', 'numbers.json');
     const span = file.span(0, file.contents.length);
     expect(span.highlight('Bad data')).toBe(
-      '1: [\n' + '2:   1,\n' + '3:   2,\n' + '4: ]\n' + '\n' + 'Bad data'
+      '<numbers.json>:\n' +
+        '1: [\n' +
+        '2:   1,\n' +
+        '3:   2,\n' +
+        '4: ]\n' +
+        '\n' +
+        'Bad data'
     );
   });
 });

--- a/tests/parser/source/tokenizer/scanner.spec.ts
+++ b/tests/parser/source/tokenizer/scanner.spec.ts
@@ -256,9 +256,9 @@ describe('SourceSpan', () => {
     //             ^^^
     expect(span.highlight('Invalid name')).toBe(
       'Line 1:\n' +
-      '  {"names": ["Abe", "George"]}\n' +
-      '              ^^^\n' +
-      'Invalid name'
+        '  {"names": ["Abe", "George"]}\n' +
+        '              ^^^\n' +
+        'Invalid name'
     );
   });
 
@@ -266,12 +266,7 @@ describe('SourceSpan', () => {
     const file = new SourceFile('[\n  1,\n  2,\n]');
     const span = file.span(0, file.contents.length);
     expect(span.highlight('Bad data')).toBe(
-      '1: [\n' +
-      '2:   1,\n' +
-      '3:   2,\n' +
-      '4: ]\n' +
-      '\n' +
-      'Bad data'
+      '1: [\n' + '2:   1,\n' + '3:   2,\n' + '4: ]\n' + '\n' + 'Bad data'
     );
   });
 });

--- a/tests/parser/source/tokenizer/scanner.spec.ts
+++ b/tests/parser/source/tokenizer/scanner.spec.ts
@@ -84,12 +84,20 @@ describe('SourceScanner', () => {
   });
 });
 
-describe(`${SourceFile}`, () => {
+describe('SourceFile', () => {
   it('should calculate number of lines', () => {
     const file = new SourceFile('aaa\nbbbbb\r\nccc\n\r');
     const lines = file.lines;
     expect(lines).toBe(4);
     expect(lines).toEqual(file.lines);
+  });
+
+  it('should read a specific line in the file', () => {
+    const file = new SourceFile('aaa\nbbbbb\r\nccc\n\r');
+    expect(file.readLine(0)).toBe('aaa');
+    expect(file.readLine(1)).toBe('bbbbb');
+    expect(file.readLine(2)).toBe('');
+    expect(file.readLine(3)).toBe('ccc');
   });
 
   describe('should compute the line number of an offset', () => {
@@ -173,7 +181,7 @@ describe(`${SourceFile}`, () => {
   });
 });
 
-it(`${SourceLocation} should have sensible defaults`, () => {
+it('SourceLocation should have sensible defaults', () => {
   const a = new SourceLocation(6, {
     column: 2,
     line: 1,
@@ -191,7 +199,7 @@ it(`${SourceLocation} should have sensible defaults`, () => {
   expect(b.source).toBeUndefined();
 });
 
-describe(`${SourceSpan}`, () => {
+describe('SourceSpan', () => {
   it('should disallow a negative start', () => {
     expect(() => {
       return new SourceSpan(
@@ -238,6 +246,32 @@ describe(`${SourceSpan}`, () => {
     );
     expect(span.message('Invalid name')).toBe(
       'line 1, column 13 of names.json: Invalid name'
+    );
+  });
+
+  it('should return a highlighted message from 1 line', () => {
+    const file = new SourceFile('{"names": ["Abe", "George"]}');
+    const span = file.span(12, 15);
+    // {"names": ["Abe", "George"]}
+    //             ^^^
+    expect(span.highlight('Invalid name')).toBe(
+      'Line 1:\n' +
+      '  {"names": ["Abe", "George"]}\n' +
+      '              ^^^\n' +
+      'Invalid name'
+    );
+  });
+
+  it('should return a highlighted message from >1 line', () => {
+    const file = new SourceFile('[\n  1,\n  2,\n]');
+    const span = file.span(0, file.contents.length);
+    expect(span.highlight('Bad data')).toBe(
+      '1: [\n' +
+      '2:   1,\n' +
+      '3:   2,\n' +
+      '4: ]\n' +
+      '\n' +
+      'Bad data'
     );
   });
 });


### PR DESCRIPTION
After:

```
main => (0 $)

Line 2:
  main => (0 $)
             ^
Expected expression, got ")"
```

If pulling out `SourceSpan` instances is too expensive in the future, we can make them lazy and/or have a more optimized mode of the compiler that uses less memory/overhead.