### PR TITLE
Add a new sane Lexer.

### DIFF
--- a/src/agnostic/strings.ts
+++ b/src/agnostic/strings.ts
@@ -16,12 +16,31 @@ export const enum Characters {
 
   // Letters
   $A = 65,
+  $E = 69,
+  $F = 70,
+  $X = 88,
   $Z = 90,
   $a = 97,
+  $e = 101,
+  $f = 102,
+  $x = 120,
   $z = 122,
 
   // Symbols
   $_ = 95,
+  $EQUALS = 61,
+  $LANGLE = 60,
+  $RANGLE = 62,
+  $LPAREN = 40,
+  $RPAREN = 41,
+  $LCURLY = 123,
+  $RCURLY = 125,
+  $PERIOD = 46,
+  $MINUS = 45,
+  $PLUS = 43,
+  $SLASH = 47,
+  $STAR = 42,
+  $SQUOTE = 39,
 
   // Misc
   $CR = 13,
@@ -35,6 +54,17 @@ export const enum Characters {
  */
 export function isDigit(character: number): boolean {
   return character >= Characters.$0 && character <= Characters.$9;
+}
+
+/**
+ * Returns whether @param character is a hexadecimel digit.
+ */
+export function isHexadecimel(character: number): boolean {
+  return (
+    (character >= Characters.$A && character <= Characters.$F) ||
+    (character >= Characters.$a && character <= Characters.$f) ||
+    isDigit(character)
+  );
 }
 
 /**

--- a/src/language/lexer.ts
+++ b/src/language/lexer.ts
@@ -1,0 +1,385 @@
+import { ISourceSpan, StringScanner } from '../agnostic/scanner';
+import {
+  Characters,
+  isDigit,
+  isHexadecimel,
+  isLetter,
+  isWhiteSpace,
+} from '../agnostic/strings';
+
+function isIdentifier(character: number): boolean {
+  return isIdentifierStart(character) || isDigit(character);
+}
+
+function isIdentifierStart(character: number): boolean {
+  return isLetter(character) || character === Characters.$_;
+}
+
+/**
+ * Tokenizes and returns @param program as a series of @see Token.
+ */
+export function tokenize(program: string, onError?: ErrorReporter): Token[] {
+  return new ClutchLexer().scanProgram(new StringScanner(program), onError);
+}
+
+/**
+ * Reports a @param message at the provided @param span.
+ */
+export type ErrorReporter = (span: ISourceSpan, error: string) => void;
+
+export enum TokenKind {
+  // Literals
+  IDENTIFIER = 'Identifier',
+  STRING = 'String',
+  NUMBER = 'Number',
+
+  // Keywords
+  CLASS = 'class',
+  ELSE = 'else',
+  FALSE = 'false',
+  FOR = 'for',
+  IF = 'if',
+  LET = 'let',
+  RETURN = 'return',
+  SUPER = 'super',
+  THIS = 'this',
+  TRUE = 'true',
+  WHILE = 'while',
+
+  // Symbols
+  ARROW = '=>',
+  LEFT_PAREN = '(',
+  RIGHT_PAREN = ')',
+  LEFT_CURLY = '{',
+  RIGHT_CURLY = '}',
+  PERIOD = '.',
+  PLUS = '+',
+  MINUS = '-',
+  STAR = '*',
+  SLASH = '/',
+  ASSIGNMENT = '=',
+  EQUALITY = '==',
+  IDENTITY = '===',
+  GREATER_THAN = '>',
+  GREATER_THAN_OR_EQUAL = '>=',
+  LESS_THAN = '<',
+  LESS_THAN_OR_EQUAL = '<=',
+
+  // Misc
+  KEYWORD = '<KEYWORD>',
+  EOF = '<EOF>',
+}
+
+/**
+ * A language-level lexer that yields tokens understood by the grammar.
+ */
+export class ClutchLexer {
+  public static readonly keywords: {
+    [index: string]: TokenKind;
+  } = {
+    class: TokenKind.CLASS,
+    else: TokenKind.ELSE,
+    false: TokenKind.FALSE,
+    for: TokenKind.FOR,
+    if: TokenKind.IF,
+    let: TokenKind.LET,
+    return: TokenKind.RETURN,
+    super: TokenKind.SUPER,
+    this: TokenKind.THIS,
+    while: TokenKind.WHILE,
+  };
+
+  private program!: StringScanner;
+  private onError!: ErrorReporter;
+  private position!: number;
+  private lastComments: IComment[] = [];
+
+  public scanProgram(
+    program: StringScanner,
+    onError: ErrorReporter = (span, message) => {
+      throw new SyntaxError(
+        `${message} "${span.text}" at ${span.line}:${span.column}`
+      );
+    }
+  ): Token[] {
+    this.position = 0;
+    this.program = program;
+    this.onError = onError;
+    const tokens: Token[] = [];
+    while (program.hasNext()) {
+      const token = this.scanToken();
+      if (token) {
+        tokens.push(token);
+      }
+    }
+    tokens.push(this.createToken(TokenKind.EOF, ''));
+    return tokens;
+  }
+
+  private scanToken(): Token | undefined {
+    const character = this.program.advance();
+    switch (character) {
+      case Characters.$LPAREN: // "("
+        return this.createToken(TokenKind.LEFT_PAREN);
+      case Characters.$RPAREN: // ")"
+        return this.createToken(TokenKind.RIGHT_PAREN);
+      case Characters.$LCURLY: // "{"
+        return this.createToken(TokenKind.LEFT_CURLY);
+      case Characters.$RCURLY: // "}"
+        return this.createToken(TokenKind.RIGHT_CURLY);
+      case Characters.$PERIOD: // "."
+        return this.createToken(TokenKind.PERIOD);
+      case Characters.$PLUS: // "+"
+        return this.createToken(TokenKind.PLUS);
+      case Characters.$MINUS: // "-"
+        if (isDigit(this.program.peek())) {
+          return this.scanNumber(this.program.advance());
+        }
+        return this.createToken(TokenKind.MINUS);
+      case Characters.$STAR: // "*"
+        return this.createToken(TokenKind.STAR);
+      case Characters.$EQUALS: // "=" or "=>" or "==" or "==="
+        return this.scanEquals();
+      case Characters.$LANGLE:
+        return this.createToken(
+          this.program.match(Characters.$EQUALS)
+            ? TokenKind.LESS_THAN_OR_EQUAL
+            : TokenKind.LESS_THAN
+        );
+      case Characters.$RANGLE:
+        return this.createToken(
+          this.program.match(Characters.$EQUALS)
+            ? TokenKind.GREATER_THAN_OR_EQUAL
+            : TokenKind.GREATER_THAN
+        );
+      case Characters.$SLASH:
+        return this.scanSlash();
+      case Characters.$SQUOTE:
+        return this.scanString();
+      default:
+        if (isWhiteSpace(character)) {
+          this.position = this.program.position;
+          break;
+        }
+        if (isDigit(character)) {
+          return this.scanNumber(character);
+        }
+        if (isIdentifierStart(character)) {
+          return this.scanIdentifierOrKeyword();
+        }
+        this.reportError(
+          `Unexpected character "${String.fromCharCode(character)}"`
+        );
+    }
+    return;
+  }
+
+  /**
+   * Scans a string, returning `undefined` if there was no string.
+   */
+  private scanString(): Token {
+    while (this.program.hasNext()) {
+      if (this.program.match(Characters.$SQUOTE)) {
+        this.position++;
+        let lexeme = this.substring();
+        lexeme = lexeme.substring(0, lexeme.length - 1);
+        return this.createToken(TokenKind.STRING, lexeme);
+      }
+      this.program.advance();
+    }
+    this.reportError('Unterminated string');
+    this.position++;
+    return this.createToken(TokenKind.STRING);
+  }
+
+  /**
+   * Scans any tokens that are valid numeric literals
+   */
+  private scanNumber(starting: number): Token {
+    if (starting === Characters.$0) {
+      if (
+        this.program.match(Characters.$X) ||
+        this.program.match(Characters.$x)
+      ) {
+        return this.scanHexNumber();
+      }
+    }
+    if (
+      this.program.match(Characters.$E) ||
+      this.program.match(Characters.$e)
+    ) {
+      return this.scanDigits();
+    }
+    while (this.program.hasNext()) {
+      const next = this.program.peek();
+      if (this.program.match(Characters.$PERIOD)) {
+        break;
+      }
+      if (isDigit(next)) {
+        this.program.advance();
+        continue;
+      } else {
+        break;
+      }
+    }
+    return this.scanDigits();
+  }
+
+  /**
+   * Scans any tokens that are valid hexadecimel digits, returning a number.
+   */
+  private scanHexNumber(): Token {
+    this.scanPredicate(isHexadecimel);
+    return this.createToken(TokenKind.NUMBER);
+  }
+
+  /**
+   * Scans any tokens that are valid digits, returning a number.
+   */
+  private scanDigits(): Token {
+    this.scanPredicate(isDigit);
+    return this.createToken(TokenKind.NUMBER);
+  }
+
+  /**
+   * Scans any tokens that are valid identifiers.
+   */
+  private scanIdentifierOrKeyword(): Token {
+    this.scanPredicate(isIdentifier);
+    const identifierOrKeyword = this.substring();
+    return new Token(
+      ClutchLexer.keywords[identifierOrKeyword] || TokenKind.IDENTIFIER,
+      identifierOrKeyword,
+      this.clearComments()
+    );
+  }
+
+  /**
+   * Scans tokens preceding with "=".
+   */
+  private scanEquals(): Token {
+    return this.createToken(
+      this.program.match(Characters.$RANGLE)
+        ? // "=>"
+          TokenKind.ARROW
+        : this.program.match(Characters.$EQUALS)
+          ? this.program.match(Characters.$EQUALS)
+            ? // "==="
+              TokenKind.IDENTITY
+            : // "=="
+              TokenKind.EQUALITY
+          : // "="
+            TokenKind.ASSIGNMENT
+    );
+  }
+
+  /**
+   * Scans tokens preceding with "/".
+   */
+  private scanSlash(): Token | undefined {
+    // "//"
+    if (this.program.match(Characters.$SLASH)) {
+      this.advanceToEOL();
+      this.lastComments.push({
+        lexeme: this.substring().trim(),
+        offset: this.position,
+      });
+      return;
+    }
+    // "/"
+    return this.createToken(TokenKind.SLASH);
+  }
+
+  /**
+   * Scans until the EOF or until @param predicate returns false.
+   */
+  private scanPredicate(predicate: (character: number) => boolean): void {
+    while (this.program.hasNext()) {
+      const peek = this.program.peek();
+      if (!predicate(peek)) {
+        break;
+      } else {
+        this.program.advance();
+      }
+    }
+  }
+
+  /**
+   * Advances the position of the scanner until either EOF or EOL.
+   *
+   * **NOTE**: Treats `CR+LF` as a DOS-stlye line ending, not two lines.
+   */
+  private advanceToEOL(): void {
+    while (this.program.hasNext()) {
+      // "\n" (LF)
+      if (this.program.match(Characters.$LF)) {
+        return;
+      }
+      // "\r" (CR)
+      if (this.program.match(Characters.$CR)) {
+        // "\r\n" (CR+LF)
+        this.program.match(Characters.$LF);
+        return;
+      }
+      this.program.advance();
+    }
+  }
+
+  /**
+   * Returns a new token with a @param kind and the current substring.
+   */
+  private createToken(kind: TokenKind, content = this.substring()): Token {
+    return new Token(kind, content, this.clearComments());
+  }
+
+  /**
+   * Clear and retrieve comments lexed.
+   */
+  private clearComments(): IComment[] {
+    const comments = this.lastComments;
+    this.lastComments = [];
+    return comments;
+  }
+
+  /**
+   * Returns the current substring, advancing the position counter.
+   */
+  private substring(): string {
+    const start = this.position;
+    const end = this.program.position;
+    this.position = end;
+    return this.program.substring(start, end);
+  }
+
+  /**
+   * Reports a lexical @param error occurring at @param offset.
+   */
+  private reportError(error: string, offset = this.position): void {
+    this.onError(this.program.source.span(offset, offset + 1), error);
+  }
+}
+
+/**
+ * A scanned token from @function tokenize.
+ */
+export interface IToken {
+  readonly kind: TokenKind;
+  readonly lexeme: string;
+  readonly comments: IComment[];
+}
+
+/**
+ * Implementation of @interface IToken private to @function tokenize.
+ */
+class Token implements IToken {
+  constructor(
+    public readonly kind: TokenKind,
+    public readonly lexeme: string,
+    public readonly comments: IComment[]
+  ) {}
+}
+
+export interface IComment {
+  readonly lexeme: string;
+  readonly offset: number;
+}

--- a/test/agnostic/scanner.spec.ts
+++ b/test/agnostic/scanner.spec.ts
@@ -2,10 +2,10 @@
 
 import {
   SourceFile,
-  StringLexer,
   StringScanner,
   StringSpan,
 } from '../../src/agnostic/scanner';
+import { Characters } from '../../src/agnostic/strings';
 
 describe('StringSpan', () => {
   describe('should throw on an invalid', () => {
@@ -138,16 +138,15 @@ describe('StringScanner', () => {
     scanner.reset();
     expect(scanner.position).toBe(0);
   });
-});
 
-it('StringLexer should scan and fetch tokens', () => {
-  const lexer = new StringLexer(new StringScanner('AAA111if'));
-  expect(lexer.scanWhiteSpace()).toBe(false);
-  expect(lexer.scanLetters()).toBe(true);
-  expect(lexer.nextToken).toBe('AAA');
-  expect(lexer.scanDigits()).toBe(true);
-  expect(lexer.nextToken).toBe('111');
-  expect(lexer.scanExactly('else')).toBe(false);
-  expect(lexer.scanExactly('if')).toBe(true);
-  expect(lexer.nextToken).toBe('if');
+  it('should peek and match', () => {
+    const scanner = new StringScanner('AB');
+    expect(scanner.peek()).toBe(Characters.$A);
+    expect(scanner.position).toBe(0);
+    expect(scanner.match(Characters.$A)).toBe(true);
+    expect(scanner.match(Characters.$Z)).toBe(false);
+    expect(scanner.position).toBe(1);
+    expect(scanner.match('B')).toBe(true);
+    expect(scanner.position).toBe(2);
+  });
 });

--- a/test/agnostic/strings.spec.ts
+++ b/test/agnostic/strings.spec.ts
@@ -1,5 +1,6 @@
 import {
   isDigit,
+  isHexadecimel,
   isLetter,
   isNewLine,
   isWhiteSpace,
@@ -62,6 +63,28 @@ describe('', () => {
       true, // 9
       true, // 0
       false, // A
+    ]);
+    expect(
+      Array.from(toChars('0123ABCDEFGabcdefg').map(isHexadecimel))
+    ).toEqual([
+      true, // 0
+      true, // 1
+      true, // 2
+      true, // 3
+      true, // A
+      true, // B
+      true, // C
+      true, // D
+      true, // E
+      true, // F
+      false, // G
+      true, // a
+      true, // b
+      true, // c
+      true, // d
+      true, // e
+      true, // f
+      false, // g
     ]);
   });
 

--- a/test/language/lexer.spec.ts
+++ b/test/language/lexer.spec.ts
@@ -1,0 +1,214 @@
+import { ClutchLexer, tokenize, TokenKind } from '../../src/language/lexer';
+
+/**
+ * Tokenizes @param program as simple JS objects for testing.
+ */
+function tokenizeKinds(program: string): TokenKind[] {
+  return tokenize(program).map(t => t.kind);
+}
+
+describe('tokenize', () => {
+  it('should scan an empty file', () => {
+    expect(tokenizeKinds('')).toEqual([TokenKind.EOF]);
+  });
+
+  it('should scan a file of completely whitespace', () => {
+    expect(tokenizeKinds('  \n  \n\r  \r  ')).toEqual([TokenKind.EOF]);
+  });
+
+  it('should scan parentheses', () => {
+    expect(
+      tokenizeKinds(`
+      (
+        (
+          ()
+        )
+      )
+    `)
+    ).toEqual([
+      TokenKind.LEFT_PAREN,
+      TokenKind.LEFT_PAREN,
+      TokenKind.LEFT_PAREN,
+      TokenKind.RIGHT_PAREN,
+      TokenKind.RIGHT_PAREN,
+      TokenKind.RIGHT_PAREN,
+      TokenKind.EOF,
+    ]);
+  });
+
+  it('should scan curlies', () => {
+    expect(
+      tokenizeKinds(`
+      {
+        {
+          {}
+        }
+      }
+    `)
+    ).toEqual([
+      TokenKind.LEFT_CURLY,
+      TokenKind.LEFT_CURLY,
+      TokenKind.LEFT_CURLY,
+      TokenKind.RIGHT_CURLY,
+      TokenKind.RIGHT_CURLY,
+      TokenKind.RIGHT_CURLY,
+      TokenKind.EOF,
+    ]);
+  });
+
+  it('should scan operators', () => {
+    expect(
+      tokenizeKinds(`
+      .
+      +
+      -
+      *
+      =
+      =>
+      ==
+      ===
+      >
+      >=
+      <
+      <=
+      /
+    `)
+    ).toEqual([
+      TokenKind.PERIOD,
+      TokenKind.PLUS,
+      TokenKind.MINUS,
+      TokenKind.STAR,
+      TokenKind.ASSIGNMENT,
+      TokenKind.ARROW,
+      TokenKind.EQUALITY,
+      TokenKind.IDENTITY,
+      TokenKind.GREATER_THAN,
+      TokenKind.GREATER_THAN_OR_EQUAL,
+      TokenKind.LESS_THAN,
+      TokenKind.LESS_THAN_OR_EQUAL,
+      TokenKind.SLASH,
+      TokenKind.EOF,
+    ]);
+  });
+
+  it('should scan all valid number literals', () => {
+    expect(
+      tokenize(`
+      0
+      1
+      1.5
+      -1
+      -1.5
+      3.14
+      31.4
+      0xAAA
+      0XAAA
+      0xaaa
+      0Xaaa
+      0x123
+      0X123
+      2e123
+    `).map(t => [t.kind, t.lexeme])
+    ).toEqual([
+      [TokenKind.NUMBER, '0'],
+      [TokenKind.NUMBER, '1'],
+      [TokenKind.NUMBER, '1.5'],
+      [TokenKind.NUMBER, '-1'],
+      [TokenKind.NUMBER, '-1.5'],
+      [TokenKind.NUMBER, '3.14'],
+      [TokenKind.NUMBER, '31.4'],
+      [TokenKind.NUMBER, '0xAAA'],
+      [TokenKind.NUMBER, '0XAAA'],
+      [TokenKind.NUMBER, '0xaaa'],
+      [TokenKind.NUMBER, '0Xaaa'],
+      [TokenKind.NUMBER, '0x123'],
+      [TokenKind.NUMBER, '0X123'],
+      [TokenKind.NUMBER, '2e123'],
+      [TokenKind.EOF, ''],
+    ]);
+  });
+
+  it('should scan strings', () => {
+    expect(
+      tokenize(`
+      'Hello'
+      'Hello World'
+      'Hello
+        World
+          !'
+    `).map(t => t.lexeme)
+    ).toEqual([
+      'Hello',
+      'Hello World',
+      'Hello\n        World\n          !',
+      '',
+    ]);
+  });
+
+  it('should scan strings without a terminator', () => {
+    expect(() => tokenize("'Hello")).toThrowError(SyntaxError);
+  });
+
+  it('should scan an invalid character', () => {
+    expect(() => tokenize('5 $ 2')).toThrowError(SyntaxError);
+  });
+
+  it('should scan strings with error recovery', () => {
+    expect(
+      tokenize("'Hello", (_, __) => {
+        /* Intentional */
+      }).map(t => t.lexeme)
+    ).toEqual(['Hello', '']);
+  });
+
+  it('should scan comments', () => {
+    expect(
+      tokenize(`
+      // One A
+      // One B
+      1
+      2 // Two
+      3
+      // Three
+    `).map(t => {
+        return [t.kind, t.comments.map(c => c.lexeme)];
+      })
+    ).toEqual([
+      [TokenKind.NUMBER, ['// One A', '// One B']],
+      [TokenKind.NUMBER, []],
+      [TokenKind.NUMBER, ['// Two']],
+      [TokenKind.EOF, ['// Three']],
+    ]);
+  });
+
+  it('should scan comments with DOS-style line endings', () => {
+    expect(
+      tokenize(`a // A\n\rb // B\rc // C\n`).map(t => {
+        return [t.kind, t.comments.map(c => c.lexeme)];
+      })
+    ).toEqual([
+      [TokenKind.IDENTIFIER, []],
+      [TokenKind.IDENTIFIER, ['// A']],
+      [TokenKind.IDENTIFIER, ['// B']],
+      [TokenKind.EOF, ['// C']],
+    ]);
+  });
+
+  it('should scan identifiers', () => {
+    expect(
+      tokenize(`
+      arg1
+      fooBar
+      x_thing
+    `).map(t => t.lexeme)
+    ).toEqual(['arg1', 'fooBar', 'x_thing', '']);
+  });
+
+  it('should scan all valid keywords', () => {
+    expect(
+      tokenizeKinds(`
+    ${Object.keys(ClutchLexer.keywords).join('  \n')}
+    `)
+    ).toEqual(Object.values(ClutchLexer.keywords).concat(TokenKind.EOF));
+  });
+});


### PR DESCRIPTION
Not yet used in the CLI, only in tests. Will replace in future PR.

* Uses a sane scanning strategy (mostly from http://craftinginterpreters.com/scanning.html#recognizing-lexemes).
* Replaces all regular expressions with character checks.
* Simplifies the tokenizing to understand less of the grammar, only characters.