### PR TITLE
Add basic constexpr evaluator

### DIFF
--- a/src/language/parser/evaluator/constexpr.ts
+++ b/src/language/parser/evaluator/constexpr.ts
@@ -1,0 +1,151 @@
+import {IToken} from '../../lexer';
+import {BinaryExpression, ConditionalExpression, GroupExpression, InvokeExpression, LiteralBoolean, LiteralIdentifier, LiteralNumber, LiteralString, ReturnStatement, UnaryExpression, VariableDeclarationStatement} from '../../parser';
+import {AstNode, FileRoot, FunctionDeclaration} from '../nodes/nodes';
+import {Operator} from '../nodes/precedence';
+import {AstVisitor} from '../visitors/abstract';
+
+export function evaluateConstExpression(node: AstNode): AstNode {
+  return node.accept(new ConstExpressionVisitor(), {});
+}
+
+// defeat typescript checking.
+var token: IToken;
+
+enum ConstExprErrorMessage {
+  DEFAULT_ERROR_STRING = 'Unsupported constexpr',
+  MAXIMUM_DEPTH = 'Maximum depth reached',
+  FILE_ROOT_UNSUPPORTED = 'Fileroot not supported',
+  IDENTIFIER_UNSUPPORTED = 'Identifiers not supported',
+  VARIABLE_DECLARATION_UNSUPPORTED = 'Cannot declare variables',
+  FUNCTION_DECLARATION_UNSUPPORTED = 'Cannot declare functions',
+  CONDITIONAL_UNSUPPORTED = 'Cannot evaluate conditionals',
+  INVOKE_UNSUPPORTED = 'Cannot invoke functions',
+  RETURN_STATEMENT_ERROR = 'Cannot early return',
+}
+
+interface Context {}
+
+class ConstExpressionVisitor extends AstVisitor<AstNode, Context> {
+  public visitFileRoot(_: FileRoot, __: Context): AstNode {
+    throw new Error(ConstExprErrorMessage.FILE_ROOT_UNSUPPORTED);
+  }
+
+  public visitBinaryExpression(node: BinaryExpression, context: Context):
+      AstNode {
+    const left: AstNode = node.left.accept(this, context);
+    const right: AstNode = node.right.accept(this, context);
+    if (left instanceof LiteralNumber && right instanceof LiteralNumber) {
+      switch (node.operator) {
+        case Operator.Addition:
+          return new LiteralNumber(token, left.value + right.value);
+        case Operator.Subtraction:
+          return new LiteralNumber(token, left.value - right.value);
+        case Operator.Multiplication:
+          return new LiteralNumber(token, left.value * right.value);
+        case Operator.Division:
+          return new LiteralNumber(token, left.value / right.value);
+        case Operator.Remainder:
+          return new LiteralNumber(token, left.value % right.value);
+        case Operator.Equality:
+          return new LiteralBoolean(token, left.value == right.value);
+        case Operator.GreaterThan:
+          return new LiteralBoolean(token, left.value > right.value);
+        case Operator.GreaterThanOrEqual:
+          return new LiteralBoolean(token, left.value >= right.value);
+        case Operator.LessThan:
+          return new LiteralBoolean(token, left.value < right.value);
+        case Operator.LessThanOrEqual:
+          return new LiteralBoolean(token, left.value <= right.value);
+        case Operator.Inequality:
+          return new LiteralBoolean(token, left.value != right.value);
+      }
+    } else if (
+        left instanceof LiteralBoolean && right instanceof LiteralBoolean) {
+      switch (node.operator) {
+        case Operator.LogicalAnd:
+          return new LiteralBoolean(token, left.value && right.value);
+        case Operator.LogicalOr:
+          return new LiteralBoolean(token, left.value || right.value);
+        case Operator.Equality:
+          return new LiteralBoolean(token, left.value == right.value);
+        case Operator.Inequality:
+          return new LiteralBoolean(token, left.value != right.value);
+      }
+    }
+    throw new Error(ConstExprErrorMessage.DEFAULT_ERROR_STRING);
+  }
+
+  public visitUnaryExpression(node: UnaryExpression, context: Context):
+      AstNode {
+    const target: AstNode = node.target.accept(this, context);
+    if (target instanceof LiteralNumber) {
+      const value: number = target.value
+      switch (node.operator) {
+        case Operator.PostfixDecrement:
+          return new LiteralNumber(token, value);
+        case Operator.PostfixIncrement:
+          return new LiteralNumber(token, value);
+        case Operator.PrefixIncrement:
+          return new LiteralNumber(token, value + 1);
+        case Operator.PrefixDecrement:
+          return new LiteralNumber(token, value - 1);
+        case Operator.UnaryNegative:
+          return new LiteralNumber(token, -value);
+      }
+    } else if (target instanceof LiteralBoolean) {
+      switch (node.operator) {
+        case Operator.LogicalNot:
+          return new LiteralBoolean(token, !target.value);
+      }
+    }
+    throw new Error(ConstExprErrorMessage.DEFAULT_ERROR_STRING);
+  }
+
+  public visitGroupExpression(node: GroupExpression, context: Context):
+      AstNode {
+    return node.expression.accept(this, context);
+  }
+
+  public visitConditionalExpression(_: ConditionalExpression, __: Context):
+      AstNode {
+    throw new Error(ConstExprErrorMessage.CONDITIONAL_UNSUPPORTED);
+  }
+
+  public visitInvokeExpression(_: InvokeExpression, __: Context): AstNode {
+    throw new Error(ConstExprErrorMessage.INVOKE_UNSUPPORTED);
+  }
+
+  public visitLiteralBoolean(node: LiteralBoolean, __: Context): AstNode {
+    return node;
+  }
+
+  public visitLiteralNumber(node: LiteralNumber, __: Context): AstNode {
+    return node;
+  }
+
+  public visitLiteralString(node: LiteralString, __: Context): AstNode {
+    return node;
+  }
+
+  public visitSimpleName(_: LiteralIdentifier, __: Context): AstNode {
+    throw new Error(ConstExprErrorMessage.IDENTIFIER_UNSUPPORTED);
+  }
+
+
+  public visitReturnStatement(_: ReturnStatement, __: Context): AstNode {
+    throw new Error(ConstExprErrorMessage.RETURN_STATEMENT_ERROR);
+  }
+
+  public visitVariableDeclarationStatement(
+      _: VariableDeclarationStatement,
+      ): AstNode {
+    // Cannot declare variables.
+    throw new Error(ConstExprErrorMessage.VARIABLE_DECLARATION_UNSUPPORTED);
+  }
+
+  public visitFunctionDeclaration(
+      _: FunctionDeclaration,
+      ): AstNode {
+    throw new Error(ConstExprErrorMessage.FUNCTION_DECLARATION_UNSUPPORTED);
+  }
+}

--- a/src/language/parser/parse/expressions.ts
+++ b/src/language/parser/parse/expressions.ts
@@ -306,7 +306,7 @@ export class ExpressionParser extends AbstractParser {
       case '+':
         return Operator.UnaryPositive;
       case '!':
-        return Operator.UnaryNegative;
+        return Operator.LogicalNot;
       default:
         // TODO: Test.
         /* istanbul ignore next */

--- a/test/language/parser/constexpr/operators.spec.ts
+++ b/test/language/parser/constexpr/operators.spec.ts
@@ -1,0 +1,90 @@
+import {tokenize} from '../../../../src/language/lexer';
+import {ClutchParser, LiteralBoolean, LiteralNumber, LiteralString} from '../../../../src/language/parser';
+import {evaluateConstExpression} from '../../../../src/language/parser/evaluator/constexpr';
+
+
+function evaluate(source: string): Object {
+  const tokens = tokenize(source);
+  const expression = new ClutchParser(tokens).parseExpression();
+  const node = evaluateConstExpression(expression);
+  if (node instanceof LiteralNumber || node instanceof LiteralBoolean ||
+      node instanceof LiteralString) {
+    return node.value;
+  }
+  throw new Error('Not a value');
+}
+
+describe('ConstExpr', () => {
+  it('arithmetic', () => {
+    const table: [string, number][] = [
+      ['1 + 1', 2],
+      ['100 + -5', 95],
+      ['1 - 1', 0],
+      ['10 - 5', 5],
+      ['2 * 3', 6],
+      ['1 / 2', 1 / 2],
+      ['-1 * 20', -20],
+      ['1 / 0', Number.POSITIVE_INFINITY],
+      ['1 % 2', 1],
+      ['6 % 2', 0],
+      ['6 + 4 * 3 - 10 / 5', 16],
+      ['(5 + 2) * 3', 21],
+      ['++1', 2],
+      ['--2', 1],
+      ['1++', 1],
+      ['1--', 1],
+    ];
+    for (const [question, answer] of table) {
+      expect(evaluate(question)).toEqual(answer);
+    }
+  });
+
+  it('numeric comparison', () => {
+    const table: [string, boolean][] = [
+      ['1 == 1', true],
+      ['1 == 2', false],
+      ['1 != 1', false],
+      ['1 != 2', true],
+      ['1 > 2', false],
+      ['1 > 0', true],
+      ['1 < 0', false],
+      ['1 < 2', true],
+      ['1 <= 1', true],
+      ['1 <= 2', true],
+      ['1 <= 0', false],
+      ['1 >= 1', true],
+      ['1 >= 0', true],
+      ['1 >= 2', false],
+      ['(1 > 2)', false],
+    ];
+    for (const [question, answer] of table) {
+      expect(evaluate(question)).toEqual(answer);
+    }
+  });
+
+  it('boolean logic', () => {
+    const table: [string, boolean][] = [
+      ['true && true', true],
+      ['true && false', false],
+      ['true || false', true],
+      ['false || false', false],
+      ['!true', false],
+      ['!false', true],
+      ['true != true', false],
+      ['false == false', true],
+    ];
+    for (const [question, answer] of table) {
+      expect(evaluate(question)).toEqual(answer);
+    }
+  });
+
+
+  it('strings', () => {
+    const table: [string, string][] = [
+      ['\'hello\'', 'hello'],
+    ];
+    for (const [question, answer] of table) {
+      expect(evaluate(question)).toEqual(answer);
+    }
+  });
+});

--- a/test/language/parser/constexpr/unsupported.spec.ts
+++ b/test/language/parser/constexpr/unsupported.spec.ts
@@ -1,0 +1,99 @@
+import {tokenize} from '../../../../src/language/lexer';
+import {ClutchParser} from '../../../../src/language/parser';
+import {evaluateConstExpression} from '../../../../src/language/parser/evaluator/constexpr';
+
+
+function expression(source: string): void {
+  const tokens = tokenize(source);
+  const expression = new ClutchParser(tokens).parseExpression();
+  evaluateConstExpression(expression);
+}
+
+function statement(source: string): void {
+  const tokens = tokenize(source);
+  const expression = new ClutchParser(tokens).parseStatement();
+  evaluateConstExpression(expression);
+}
+
+function file(source: string): void {
+  const tokens = tokenize(source);
+  const expression = new ClutchParser(tokens).parseFileRoot();
+  evaluateConstExpression(expression);
+}
+
+function declare(source: string): void {
+  const tokens = tokenize(source);
+  const expression = new ClutchParser(tokens).parseFileRoot();
+  evaluateConstExpression(expression.topLevelElements[0]);
+}
+
+describe('ConstExpr', () => {
+  it('conditional expressions unsupported', () => {
+    expect(() => expression('if (1 > 2) { 4 } else { 5 }')).toThrow();
+  });
+
+  it('conditional statement unsupported', () => {
+    expect(() => statement('if (1 > 2) { 4 } else { 5 }')).toThrow();
+  });
+  it('function invocation unsupported', () => {
+    expect(() => expression('fib(2)')).toThrow();
+  });
+
+  it('function declarations unsupported', () => {
+    expect(
+        () => declare('fib(n) -> if n < 2 then n else fib(n - 1) + fib(n - 2)'))
+        .toThrow();
+  });
+
+  it('boolean type error', () => {
+    expect(() => expression('true + false')).toThrow();
+  });
+
+  it('boolean type error 2', () => {
+    expect(() => expression('true + 2')).toThrow();
+  });
+
+  it('boolean type error 3', () => {
+    expect(() => expression('3 - false')).toThrow();
+  });
+
+  it('numeric type error', () => {
+    expect(() => expression('2 && 3')).toThrow();
+  });
+
+  it('numeric type error 2', () => {
+    expect(() => expression('2 && true')).toThrow();
+  });
+
+  it('numeric unary type error', () => {
+    expect(() => expression('!2')).toThrow();
+  });
+
+  it('boolean unary type error', () => {
+    expect(() => expression('-true')).toThrow();
+  });
+
+  it('boolean unary type error 2', () => {
+    expect(() => expression('++true')).toThrow();
+  });
+
+  it('numeric unary type error', () => {
+    expect(() => expression('-\'1232\'')).toThrow();
+  });
+
+  it('simple name unsupported', () => {
+    expect(() => expression('foo')).toThrow();
+  });
+
+  it('variable declarations unsupported', () => {
+    expect(() => statement('let message = \'Hello\'')).toThrow();
+  });
+
+  it('return statement unsupported', () => {
+    expect(() => statement('return 2')).toThrow();
+  });
+
+  it('file root unsupported', () => {
+    expect(() => file('main() -> {}')).toThrow();
+  })
+});


### PR DESCRIPTION
This only evaluates a subset of operators on numbers and booleans.  Support for conditionals, local variables, and recursion can be added by tracking scope and recursion depth via Context (currently unused). This has no opinion about how it is triggered, but I could imagine a hint such as `constexpr` triggering a second pass on the parser which would replace the AST node with the evaluated node.

Note: because tokens are not optional, the synthetic nodes I construct have a null token - looking for a better solution here.

* Bugfix: `!true` was parsed as `-true`.